### PR TITLE
Fixes SessionToken problem 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,6 +9,8 @@
 .npmignore
 .tesselinclude
 .vscode/
+.idea/
+.idea
 apis/*.normal.json
 appveyor.yml
 bower.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG 
 
+## [1.0.2] - 2020-10-22
+Fixed bug with temporary credentials and sessions not working
+
 
 ## [1.0.0] - 2020-06-18
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IMPORTANT: Latest Version
 
-The current version is 1.0.0. Please see the [changelog](./CHANGELOG.md) for details on version history.
+The current version is 1.0.2. Please see the [changelog](./CHANGELOG.md) for details on version history.
 
 # What
 

--- a/lib/sigv4-auth-provider.js
+++ b/lib/sigv4-auth-provider.js
@@ -122,7 +122,7 @@ SigV4AuthProvider.prototype.newAuthenticator = function () {
     region: this.region,
     accessKeyId: this.accessKeyId,
     secretAccessKey: this.secretAccessKey,
-		sessionToken: this.sessionToken
+    sessionToken: this.sessionToken
   });
 };
 
@@ -191,6 +191,7 @@ SigV4Authenticator.prototype.evaluateChallenge = function (challenge, callback) 
     region: this.region,
     accessKeyId: this.accessKeyId,
     secretAccessKey: this.secretAccessKey,
+    sessionToken: this.sessionToken,
     date: dateToUse,
     nonce: nonce
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sigv4-auth-cassandra-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A sigv4 authentication plugin for open-source Datastax NodeJS Driver for Apache Cassandra",
   "main": "index.js",
   "scripts": {

--- a/test/unit/sigv4-auth-provider-tests.js
+++ b/test/unit/sigv4-auth-provider-tests.js
@@ -106,12 +106,13 @@ describe('SigV4Authenticator', () => {
       region: 'us-west-2',
       accessKeyId: 'UserID-1',
       secretAccessKey: 'UserSecretKey-1',
+      sessionToken: 'SessiosnToken-1',
       date: new Date(1591742511000)
     });
 
     it('should call callback with Signed Request', () => {
       let nonceBuffer = Buffer.from("nonce=91703fdc2ef562e19fbdab0f58e42fe5");
-      let expected = "signature=7f3691c18a81b8ce7457699effbfae5b09b4e0714ab38c1292dbdf082c9ddd87,access_key=UserID-1,amzdate=2020-06-09T22:41:51.000Z";
+      let expected = "signature=7f3691c18a81b8ce7457699effbfae5b09b4e0714ab38c1292dbdf082c9ddd87,access_key=UserID-1,amzdate=2020-06-09T22:41:51.000Z,session_token=SessiosnToken-1";
 
       let calledCallback = false;
       target.evaluateChallenge(nonceBuffer, (err, buff) => {


### PR DESCRIPTION
This fixes a session token bug that was found in prod where temporary
credentials would result in an invalid claims exception.  This was
due to missing a passing the session token to the calculation function
test was amended to catch this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
