### PR TITLE
unify manual and credential chain credentials

### DIFF
--- a/lib/sigv4-auth-provider.js
+++ b/lib/sigv4-auth-provider.js
@@ -39,9 +39,12 @@ function SigV4AuthProvider( {
     accessKeyId,
     secretAccessKey,
     sessionToken} = {}) {
-  this.secretAccessKey = secretAccessKey;
-  this.accessKeyId = accessKeyId;
-  this.sessionToken = sessionToken;
+  if (accessKeyId) {
+    const credentials = new AWS.Credentials(accessKeyId, secretAccessKey, sessionToken);
+    this.chain = new AWS.CredentialProviderChain([credentials]);
+  } else {
+    this.chain = new AWS.CredentialProviderChain();
+  }
 
   this.region = region || SigV4AuthProvider.getRegionFromEnv();
 
@@ -50,37 +53,9 @@ function SigV4AuthProvider( {
     throw new Error('[SIGV4_MISSING_REGION] No region provided.  You must either provide a region or set '
     + 'environment variable [AWS_REGION]');
   }
-
-  // validate access ID
-  if (!this.accessKeyId) {
-    const creds = getCredentialChainCreds();
-
-    if (!creds) {
-      throw new Error('[SIGV4_NO_CREDS] No credentials provided and no default creds found.');
-    }
-    this.secretAccessKey = creds.secretAccessKey;
-    this.accessKeyId = creds.accessKeyId;
-    this.sessionToken = creds.sessionToken;
-  }
 }
 
 util.inherits(SigV4AuthProvider, cass.auth.AuthProvider);
-
-/**
- * Retrieve Credentials from default chain
- * @returns AWS.crentials object
- * @private
- */
-function getCredentialChainCreds() {
-  let chain = new AWS.CredentialProviderChain();
-
-  let result;
-  chain.resolve((err, c) => {
-    result = c;
-  });
-
-  return result;
-};
 
 /**
  * Pull region from enviornment
@@ -120,9 +95,7 @@ SigV4AuthProvider.extractNonce = (buf) => {
 SigV4AuthProvider.prototype.newAuthenticator = function () {
   return new SigV4Authenticator({
     region: this.region,
-    accessKeyId: this.accessKeyId,
-    secretAccessKey: this.secretAccessKey,
-    sessionToken: this.sessionToken
+    chain: this.chain,
   });
 };
 
@@ -136,22 +109,16 @@ SigV4AuthProvider.prototype.newAuthenticator = function () {
  * @extends cass.auth.Authenticator
  * @param {object} options
  * @param {string} options.region - aws region such as 'us-west-2'.
- * @param {string} options.accessKeyId - Access key id from an AccessKey pair
- * @param {string} options.secretAccessKey - Password from an AccessKey pair
- * @param {string} options.sessionToken - use this if you are using temporary credentials.
+ * @param {AWS.CredentialProviderChain} options.chain - provider chain with appropriate credentials
  * @param {Date} options.date - fixed date to use.  If not provided, we use current date.
  * @constructor
  */
 function SigV4Authenticator({
   region,
-  accessKeyId,
-  secretAccessKey,
-  sessionToken,
+  chain,
   date
 } = {}) {
-  this.accessKeyId = accessKeyId;
-  this.secretAccessKey = secretAccessKey;
-  this.sessionToken = sessionToken;
+  this.chain = chain;
   this.region = region;
   this.date = date;
 }
@@ -187,16 +154,17 @@ SigV4Authenticator.prototype.evaluateChallenge = function (challenge, callback) 
 
   let dateToUse  = this.date || new Date();
 
-  let signedString =  sigv4.computeSigV4SignatureCassandraRequest({
-    region: this.region,
-    accessKeyId: this.accessKeyId,
-    secretAccessKey: this.secretAccessKey,
-    sessionToken: this.sessionToken,
-    date: dateToUse,
-    nonce: nonce
+  this.chain.resolvePromise().then((creds) => {
+    let signedString =  sigv4.computeSigV4SignatureCassandraRequest({
+      region: this.region,
+      accessKeyId: creds.accessKeyId,
+      secretAccessKey: creds.secretAccessKey,
+      sessionToken: creds.sessionToken,
+      date: dateToUse,
+      nonce: nonce
+    });
+    callback(null, Buffer.from(signedString));
   });
-
-  callback(null, Buffer.from(signedString));
 };
 
 module.exports =

--- a/test/unit/sigv4-auth-provider-tests.js
+++ b/test/unit/sigv4-auth-provider-tests.js
@@ -16,6 +16,7 @@
 
 'use strict';
 
+const AWS = require('aws-sdk');
 const lib = require('../../lib/sigv4-auth-provider.js');
 const assert = require('assert');
 
@@ -66,7 +67,7 @@ describe('SigV4AuthProvider',  () => {
       assert.equal(provider.region, "us-east-23");
     });
 
-    it('should use default if Provided',  () => {
+    it('should use default region if Provided',  () => {
       let provider = new SigV4AuthProvider({accessKeyId:'key'});
 
       assert.equal(provider.region, "ENV_DEFAULT_REGION");
@@ -79,6 +80,37 @@ describe('SigV4AuthProvider',  () => {
           "[SIGV4_MISSING_REGION] No region provided.  You must either provide a region or set "
           + "environment variable [AWS_REGION]");
       assert.throws(() => {new SigV4AuthProvider()}, err);
+    });
+
+    it('should use provided credentials', (done) => {
+      const credentials = new AWS.Credentials('UserID-1', 'UserSecretKey-1', 'SessiosnToken-1');
+      const options = {
+        region: "us-east-23",
+        accessKeyId: "UserID-1",
+        secretAccessKey: "UserSecretKey-1",
+        sessionToken: "SessiosnToken-1"
+      };
+      let provider = new SigV4AuthProvider(options);
+      assert.ok(provider.chain);
+      assert.ok(provider.chain instanceof AWS.CredentialProviderChain);
+      assert.deepEqual(provider.chain.providers, [credentials]);
+      provider.chain.resolvePromise().then((creds) => {
+        assert.deepEqual(creds, {
+          accessKeyId: 'UserID-1',
+          expireTime: null,
+          expired: false,
+          refreshCallbacks: [],
+          sessionToken: 'SessiosnToken-1'
+        });
+        done();
+      });
+    });
+
+    it('should use default credential chain if no access key provided', () => {
+      let provider = new SigV4AuthProvider({region: "us-east-23"});
+      assert.ok(provider.chain);
+      assert.ok(provider.chain instanceof AWS.CredentialProviderChain);
+      assert.deepEqual(provider.chain.providers, AWS.CredentialProviderChain.defaultProviders);
     });
   });
 });
@@ -96,30 +128,29 @@ describe('SigV4Authenticator', () => {
         // this is a style of buffer setup that is deprecated, however
         // it is consistent with older versions of js.  We use it
         // here as a double-entry bookkeeping that our buffer is right.
-        assert.notStrictEqual(buf, new Buffer("SigV4\0\0", 'utf8'));
-      })
+        assert.notStrictEqual(buf, new Buffer.from("SigV4\0\0", 'utf8'));
+      });
     });
   });
 
   describe('#evaluateChallenge()', () => {
+    const credentials = new AWS.Credentials('UserID-1', 'UserSecretKey-1', 'SessiosnToken-1');
+    const chain = new AWS.CredentialProviderChain([credentials]);
     let target = new lib.SigV4Authenticator({
       region: 'us-west-2',
-      accessKeyId: 'UserID-1',
-      secretAccessKey: 'UserSecretKey-1',
-      sessionToken: 'SessiosnToken-1',
+      chain: chain,
       date: new Date(1591742511000)
     });
 
-    it('should call callback with Signed Request', () => {
+    it('should call callback with Signed Request', (done) => {
       let nonceBuffer = Buffer.from("nonce=91703fdc2ef562e19fbdab0f58e42fe5");
       let expected = "signature=7f3691c18a81b8ce7457699effbfae5b09b4e0714ab38c1292dbdf082c9ddd87,access_key=UserID-1,amzdate=2020-06-09T22:41:51.000Z,session_token=SessiosnToken-1";
 
       let calledCallback = false;
       target.evaluateChallenge(nonceBuffer, (err, buff) => {
         assert.equal(buff.toString(), expected);
-        calledCallback = true;
+        done();
       });
-      assert.equal(calledCallback, true);
     });
 
     it('should fail when Nonce is not found', () => {


### PR DESCRIPTION
removed a credential resolution function that always returned undefined
fetch (potentially cached) credentials when needed--at the challange

*Issue #, if available:* https://github.com/aws/aws-sigv4-auth-cassandra-nodejs-driver-plugin/issues/4

*Description of changes:* brings the manually submitted credentials and the default credentials onto the same level by leveraging `AWS.CredentialProviderChain` which will manage all issues of credential caching and retrieval for default (or externally configured) credential providers. added appropriate tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
