### PR TITLE
chore: move jsdoc to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
+    "jsdoc": "^3.6.4",
     "mocha": "^7.2.0"
   },
   "dependencies": {
     "aws-sdk": "^2.692.0",
     "cassandra-driver": "^4.6.3",
-    "crypto-js": "^4.0.0",
-    "jsdoc": "^3.6.4"
+    "crypto-js": "^4.0.0"
   }
 }


### PR DESCRIPTION
*Description of changes:*

`jsdoc` is included as a dependency of `aws-sigv4-auth-cassandra-nodejs-driver-plugin`, but it is only used at build time via the `build-jsdocs` script.

This will avoid consumers unnecessarily installing `jsdoc` when adding `aws-sigv4-auth-cassandra-nodejs-driver-plugin` as a dependency.

It should help in addressing #9, but may not completely resolve that issue. The main motivation for this change is that `jsdoc` is being flagged as vulnerable by some tools (https://github.com/jsdoc/jsdoc/issues/1991).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.