### PR TITLE
Upgrade jsdoc and mocha versions. Move jsdoc to devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^7.2.0"
+    "jsdoc": "^4.0.2",
+    "mocha": "^10.2.0"
   },
   "dependencies": {
     "aws-sdk": "^2.692.0",
     "cassandra-driver": "^4.6.3",
-    "crypto-js": "^4.0.0",
-    "jsdoc": "^3.6.4"
+    "crypto-js": "^4.0.0"
   }
 }


### PR DESCRIPTION
*Description of changes:*

* Upgrade to `jsdoc-4.0.2` and `mocha-10.2.0`
* Move `jsdoc` to the `devDependencies` block since it is only used at the build time via the `build-jsdocs` script.


Output of `npm install` after upgrade:
```
added 13 packages, removed 75 packages, changed 41 packages, and audited 148 packages in 2s

34 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

*Testing:*
* Unit tests succeeds
* API doc generation succeeds
* Integration test succeeds


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
